### PR TITLE
[AO] add custom start-docker.sh and an empty client.jks file as a preparation for production config

### DIFF
--- a/repository.yaml
+++ b/repository.yaml
@@ -5,3 +5,4 @@ leakDetectionExemptions:
     filePaths:
       - '/conf/client-dev.jks'
       - '/conf/client-qa.jks'
+      - '/conf/client.jks'

--- a/start-docker.sh
+++ b/start-docker.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+CLIENT_JKS_FILE=$(find . -type f -name client.jks)
+
+# Overwrite the keystore with a client certificate.
+if [ -n "${CLIENT_JKS}" ] ; then
+  if [ -f $CLIENT_JKS_FILE ]; then
+    echo "$CLIENT_JKS" | base64 --decode > "$CLIENT_JKS_FILE"
+  else
+    echo "Cannot find client.jks file location."
+  fi
+fi
+
+SCRIPT=$(find . -type f -name home-office-settled-status-proxy)
+exec $SCRIPT $HMRC_CONFIG -Dconfig.file=conf/home-office-settled-status-proxy.conf


### PR DESCRIPTION
This PR is to enable specifying keystore file content through a config parameter, like in: https://github.com/hmrc/app-config-production/blob/master/client-exchange-proxy.yaml#L16