### PR TITLE
[HOSS-148][AO] add support for an empty response 202 when status not found within the query date range

### DIFF
--- a/app/uk/gov/hmrc/homeofficesettledstatusproxy/connectors/ErrorCodes.scala
+++ b/app/uk/gov/hmrc/homeofficesettledstatusproxy/connectors/ErrorCodes.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.homeofficesettledstatusproxy.connectors
+
+object ErrorCodes {
+
+  val ERR_REQUEST_INVALID = "ERR_REQUEST_INVALID"
+  val ERR_NOT_FOUND = "ERR_NOT_FOUND"
+  val ERR_VALIDATION = "ERR_VALIDATION"
+  val ERR_CONFLICT = "ERR_CONFLICT"
+
+}

--- a/app/uk/gov/hmrc/homeofficesettledstatusproxy/models/StatusCheckResponse.scala
+++ b/app/uk/gov/hmrc/homeofficesettledstatusproxy/models/StatusCheckResponse.scala
@@ -41,7 +41,7 @@ object StatusCheckResponse {
 
   object HasResult {
     def unapply(response: StatusCheckResponse): Option[StatusCheckResponse] =
-      response.result.map(_ => response)
+      if (response.error.isDefined) None else Some(response)
   }
 
   object HasError {

--- a/it/uk/gov/hmrc/homeofficesettledstatusproxy/connectors/HomeOfficeRightToPublicFundsConnectorISpec.scala
+++ b/it/uk/gov/hmrc/homeofficesettledstatusproxy/connectors/HomeOfficeRightToPublicFundsConnectorISpec.scala
@@ -8,6 +8,7 @@ import uk.gov.hmrc.homeofficesettledstatusproxy.models.{OAuthToken, StatusCheckB
 import uk.gov.hmrc.homeofficesettledstatusproxy.stubs.HomeOfficeRightToPublicFundsStubs
 import uk.gov.hmrc.homeofficesettledstatusproxy.support.AppBaseISpec
 import uk.gov.hmrc.http.{HeaderCarrier, HttpErrorFunctions, HttpResponse, Upstream4xxResponse, Upstream5xxResponse}
+import uk.gov.hmrc.homeofficesettledstatusproxy.connectors.ErrorCodes._
 
 import scala.concurrent.ExecutionContext
 
@@ -79,7 +80,7 @@ class HomeOfficeRightToPublicFundsConnectorISpec
 
       result.result shouldBe None
       result.error shouldBe defined
-      result.error.get.errCode shouldBe "ERR_REQUEST_INVALID"
+      result.error.get.errCode shouldBe ERR_REQUEST_INVALID
     }
 
     "return check error when 404 response ERR_NOT_FOUND" in {
@@ -90,7 +91,7 @@ class HomeOfficeRightToPublicFundsConnectorISpec
 
       result.result shouldBe None
       result.error shouldBe defined
-      result.error.get.errCode shouldBe "ERR_NOT_FOUND"
+      result.error.get.errCode shouldBe ERR_NOT_FOUND
     }
 
     "return check error when 409 response ERR_CONFLICT" in {
@@ -101,7 +102,7 @@ class HomeOfficeRightToPublicFundsConnectorISpec
 
       result.result shouldBe None
       result.error shouldBe defined
-      result.error.get.errCode shouldBe "ERR_CONFLICT"
+      result.error.get.errCode shouldBe ERR_CONFLICT
     }
 
     "return check error when 400 response ERR_VALIDATION" in {
@@ -112,7 +113,7 @@ class HomeOfficeRightToPublicFundsConnectorISpec
 
       result.result shouldBe None
       result.error shouldBe defined
-      result.error.get.errCode shouldBe "ERR_VALIDATION"
+      result.error.get.errCode shouldBe ERR_VALIDATION
     }
 
     "throw exception if other 4xx response" in {
@@ -129,6 +130,17 @@ class HomeOfficeRightToPublicFundsConnectorISpec
       an[Upstream5xxResponse] shouldBe thrownBy {
         await(connector.statusPublicFundsByNino(request, dummyCorrelationId, dummyOAuthToken))
       }
+    }
+
+    "return empty response when 202" in {
+      givenEmptyStatusCheckResult()
+
+      val result: StatusCheckResponse =
+        await(connector.statusPublicFundsByNino(request, dummyCorrelationId, dummyOAuthToken))
+
+      result.correlationId shouldBe dummyCorrelationId
+      result.result shouldBe None
+      result.error shouldBe None
     }
   }
 
@@ -174,7 +186,7 @@ class HomeOfficeRightToPublicFundsConnectorISpec
 
       result.result shouldBe None
       result.error shouldBe defined
-      result.error.get.errCode shouldBe "ERR_REQUEST_INVALID"
+      result.error.get.errCode shouldBe ERR_REQUEST_INVALID
     }
 
     "return check error when 404 response ERR_NOT_FOUND" in {

--- a/it/uk/gov/hmrc/homeofficesettledstatusproxy/controllers/testonly/HomeOfficeSettledStatusProxyTestOnlyControllerISpec.scala
+++ b/it/uk/gov/hmrc/homeofficesettledstatusproxy/controllers/testonly/HomeOfficeSettledStatusProxyTestOnlyControllerISpec.scala
@@ -6,6 +6,7 @@ import play.api.libs.json.JsObject
 import play.api.libs.ws.{WSClient, WSResponse}
 import uk.gov.hmrc.homeofficesettledstatusproxy.stubs.HomeOfficeRightToPublicFundsStubs
 import uk.gov.hmrc.homeofficesettledstatusproxy.support.{JsonMatchers, ServerBaseISpec}
+import uk.gov.hmrc.homeofficesettledstatusproxy.connectors.ErrorCodes._
 
 class HomeOfficeSettledStatusProxyTestOnlyControllerISpec
     extends ServerBaseISpec with HomeOfficeRightToPublicFundsStubs with JsonMatchers {
@@ -68,7 +69,7 @@ class HomeOfficeSettledStatusProxyTestOnlyControllerISpec
         result.json.as[JsObject] should (haveProperty[String]("correlationId", be("sjdfhks123"))
           and haveProperty[JsObject](
             "error",
-            haveProperty[String]("errCode", be("ERR_NOT_FOUND"))
+            haveProperty[String]("errCode", be(ERR_NOT_FOUND))
           ))
       }
 
@@ -86,7 +87,7 @@ class HomeOfficeSettledStatusProxyTestOnlyControllerISpec
         result.json.as[JsObject] should (haveProperty[String]("correlationId", be("sjdfhks123"))
           and haveProperty[JsObject](
             "error",
-            haveProperty[String]("errCode", be("ERR_REQUEST_INVALID"))
+            haveProperty[String]("errCode", be(ERR_REQUEST_INVALID))
           ))
       }
 
@@ -103,7 +104,7 @@ class HomeOfficeSettledStatusProxyTestOnlyControllerISpec
         result.json.as[JsObject] should (haveProperty[String]("correlationId", be("sjdfhks123"))
           and haveProperty[JsObject](
             "error",
-            haveProperty[String]("errCode", be("ERR_VALIDATION"))
+            haveProperty[String]("errCode", be(ERR_VALIDATION))
               and havePropertyArrayOf[JsObject](
                 "fields",
                 haveProperty[String]("code")
@@ -125,14 +126,14 @@ class HomeOfficeSettledStatusProxyTestOnlyControllerISpec
         result.json.as[JsObject] should (haveProperty[String]("correlationId", be("sjdfhks123"))
           and haveProperty[JsObject](
             "error",
-            haveProperty[String]("errCode", be("ERR_REQUEST_INVALID"))))
+            haveProperty[String]("errCode", be(ERR_REQUEST_INVALID))))
       }
 
-      "respond with 400 if the service response undefined" in {
+      "respond with 400 if the service error undefined" in {
         ping.status.shouldBe(200)
 
         givenOAuthTokenGranted()
-        givenStatusCheckResponseUndefined()
+        givenStatusCheckErrorUndefined(400)
         givenAuthorisedForStride
 
         val result = publicFundsByNinoRaw(validRequestBody, "sjdfhks123")

--- a/it/uk/gov/hmrc/homeofficesettledstatusproxy/stubs/HomeOfficeRightToPublicFundsStubs.scala
+++ b/it/uk/gov/hmrc/homeofficesettledstatusproxy/stubs/HomeOfficeRightToPublicFundsStubs.scala
@@ -63,6 +63,9 @@ trait HomeOfficeRightToPublicFundsStubs {
   def givenStatusCheckResultWithRangeExample(): StubMapping =
     givenStatusPublicFundsByNinoStub(200, requestBodyWithRange, responseBodyWithStatus)
 
+  def givenEmptyStatusCheckResult(): StubMapping =
+    givenStatusPublicFundsByNinoStub(202, validRequestBody, "")
+
   def givenStatusCheckErrorWhenMissingInputField(): StubMapping = {
 
     val errorResponseBody: String =
@@ -115,14 +118,16 @@ trait HomeOfficeRightToPublicFundsStubs {
     givenStatusPublicFundsByNinoStub(404, validRequestBody, errorResponseBody)
   }
 
-  def givenStatusCheckResponseUndefined(): StubMapping = {
+  def givenStatusCheckErrorUndefined(status: Int): StubMapping = {
+
+    assert(status >= 400 && status < 500)
 
     val errorResponseBody: String =
       """{
         |  "correlationId": "sjdfhks123"
         |}""".stripMargin
 
-    givenStatusPublicFundsByNinoStub(400, validRequestBody, errorResponseBody)
+    givenStatusPublicFundsByNinoStub(status, validRequestBody, errorResponseBody)
   }
 
   def givenStatusCheckErrorWhenConflict(): StubMapping = {


### PR DESCRIPTION
This PR is to accommodate the late change introduced by the HO API team. When the user has had the status but more than 6 months ago the response will be temporarily 202 with an empty body.  