### PR TITLE
DDCE-2155: update to per-class logging

### DIFF
--- a/conf/application-json-logger.xml
+++ b/conf/application-json-logger.xml
@@ -7,7 +7,12 @@
 
     <logger name="uk.gov" level="${logger.uk.gov:-INFO}"/>
     <logger name="javax.net" level="DEBUG"/>
-    <logger name="application" level="${logger.application:-INFO}"/>
+
+    <!--  Allow /app/MicroserviceModule.scala to log  -->
+    <logger name="MicroserviceModule" level="${logger.application:-INFO}"/>
+    <!--  /wiring/MicroserviceMonitoringFilter.scala  -->
+    <logger name="wiring" level="${logger.application:-INFO}"/>
+
 
     <root level="${logger.root:-ERROR}">
         <appender-ref ref="STDOUT"/>

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -43,8 +43,6 @@
         <appender-ref ref="STDOUT_IGNORE_NETTY" />
     </logger>
 
-    <logger name="application" level="ERROR"/>
-
     <logger name="uk.gov" level="INFO"/>
 
     <logger name="play" level="INFO"/>
@@ -68,6 +66,13 @@
     <logger name="connector" level="ERROR">
         <appender-ref ref="STDOUT"/>
     </logger>
+
+    <!--  Allow /app/MicroserviceModule.scala to log  -->
+    <logger name="MicroserviceModule" level="INFO"/>
+
+    <!--  /wiring/MicroserviceMonitoringFilter.scala  -->
+    <logger name="wiring" level="INFO"/>
+
 
     <root level="ERROR">
         <appender-ref ref="FILE"/>


### PR DESCRIPTION
The `/app` dir contains a stray class `MicroserviceModule`.
It's been configured by name, producing the following output:
```
2021-07-08 17:49:23,216 level=[INFO] logger=[MicroserviceModule] thread=[play-dev-mode-akka.actor.default-dispatcher-4] rid=[] user=[] message=[Starting microservice : home-office-settled-status-proxy : in mode : Dev]
 ```